### PR TITLE
Bump GraphiQL for Strawberry

### DIFF
--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -78,12 +78,12 @@
     <script
       crossorigin
       src="https://unpkg.com/graphiql@3.8.3/graphiql.min.js"
-      integrity="sha384-Mq3vbRBY71jfjQAt/DcjxUIYY33ksal4cgdRt9U/hNPvHBCaT2JfJ/PTRiPKf0aM"
+      integrity="sha384-HbRVEFG0JGJZeAHCJ9Xm2+tpknBQ7QZmNlO/DgZtkZ0aJSypT96YYGRNod99l9Ie"
     ></script>
     <script
       crossorigin
       src="https://unpkg.com/@graphiql/plugin-explorer@3.2.5/dist/index.umd.js"
-      integrity="sha384-YN9MumWidbWKuNj8VfH5ggrFvm9YqAoIOMnKYpeGL3dr7Eg1qnQ+SAqSthdNZCjz"
+      integrity="sha384-5p6hGdlOTvUy6Wf0GauxCz+xM9YB/YYvcGG+bf9msr2eyd+KVIxgRkepHgUijedJ"
     ></script>
     <script>
       const EXAMPLE_QUERY = `# Welcome to GraphiQL 🍓

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -77,12 +77,12 @@
     <div id="graphiql" class="graphiql-container">Loading...</div>
     <script
       crossorigin
-      src="https://unpkg.com/graphiql@3.8.3/graphiql.min.css"
+      src="https://unpkg.com/graphiql@3.8.3/graphiql.min.js"
       integrity="sha384-Mq3vbRBY71jfjQAt/DcjxUIYY33ksal4cgdRt9U/hNPvHBCaT2JfJ/PTRiPKf0aM"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/@graphiql/plugin-explorer@3.2.5/dist/style.css"
+      src="https://unpkg.com/@graphiql/plugin-explorer@3.2.5/dist/index.umd.js"
       integrity="sha384-YN9MumWidbWKuNj8VfH5ggrFvm9YqAoIOMnKYpeGL3dr7Eg1qnQ+SAqSthdNZCjz"
     ></script>
     <script>

--- a/strawberry/static/graphiql.html
+++ b/strawberry/static/graphiql.html
@@ -61,15 +61,15 @@
     <link
       crossorigin
       rel="stylesheet"
-      href="https://unpkg.com/graphiql@3.0.5/graphiql.min.css"
-      integrity="sha384-yz3/sqpuplkA7msMo0FE4ekg0xdwdvZ8JX9MVZREsxipqjU4h8IRfmAMRcb1QpUy"
-    />
+      href="https://unpkg.com/graphiql@3.8.3/graphiql.min.css"
+      integrity="sha384-Mq3vbRBY71jfjQAt/DcjxUIYY33ksal4cgdRt9U/hNPvHBCaT2JfJ/PTRiPKf0aM"
+    >
 
     <link
       crossorigin
       rel="stylesheet"
-      href="https://unpkg.com/@graphiql/plugin-explorer@0.3.4/dist/style.css"
-      integrity="sha384-kOrlMT58B3t0hTVIPFqWyg1oL4DKvxHNcC1X2qugv4fXd9ehKULhhjDLvBi3HoEK"
+      href="https://unpkg.com/@graphiql/plugin-explorer@3.2.5/dist/style.css"
+      integrity="sha384-YN9MumWidbWKuNj8VfH5ggrFvm9YqAoIOMnKYpeGL3dr7Eg1qnQ+SAqSthdNZCjz"
     />
   </head>
 
@@ -77,13 +77,13 @@
     <div id="graphiql" class="graphiql-container">Loading...</div>
     <script
       crossorigin
-      src="https://unpkg.com/graphiql@3.0.5/graphiql.min.js"
-      integrity="sha384-M+Ed4RZlnWvJ8keiTju1xlV6xM5tB9tLTfoSdWPDVrK4aOOpavtruK9pz/dfuCZ/"
+      src="https://unpkg.com/graphiql@3.8.3/graphiql.min.css"
+      integrity="sha384-Mq3vbRBY71jfjQAt/DcjxUIYY33ksal4cgdRt9U/hNPvHBCaT2JfJ/PTRiPKf0aM"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/@graphiql/plugin-explorer@0.3.4/dist/index.umd.js"
-      integrity="sha384-2oonKe47vfHIZnmB6ZZ10vl7T0Y+qrHQF2cmNTaFDuPshpKqpUMGMc9jgj9MLDZ9"
+      src="https://unpkg.com/@graphiql/plugin-explorer@3.2.5/dist/style.css"
+      integrity="sha384-YN9MumWidbWKuNj8VfH5ggrFvm9YqAoIOMnKYpeGL3dr7Eg1qnQ+SAqSthdNZCjz"
     ></script>
     <script>
       const EXAMPLE_QUERY = `# Welcome to GraphiQL 🍓


### PR DESCRIPTION
There's a few changes in upstream GraphiQL (specifically https://github.com/graphql/graphiql/blob/main/packages/graphiql/CHANGELOG.md#350) that we need to roll into our own Strawberry implementation to use defer/stream syntax for GraphQL. This PR bumps GraphiQL versions similar to https://github.com/strawberry-graphql/strawberry/pull/3227/files and also verifies that the GraphiQL server runs locally as expected:
<img width="1728" alt="Screenshot 2025-04-15 at 3 55 40 PM" src="https://github.com/user-attachments/assets/f94e007a-4db9-4062-9f22-719533d89efb" />
